### PR TITLE
Corrigiendo falla de origen en pruebas de flake8

### DIFF
--- a/.psql_unittest.py
+++ b/.psql_unittest.py
@@ -200,8 +200,8 @@ class TestApplicantPostgres(unittest.TestCase):
             if len(res_dict) == 0:
                 print "WARNING: '%s' Not implement yet" % (table_name, )
             self.assertEqual(
-                self.required_records[table_name] == len(res_dict)
-                or len(res_dict) == 0,
+                self.required_records[table_name] == len(res_dict) or
+                len(res_dict) == 0,
                 True,
                 "Request records in table '%s'=%d. Records found=%d"
                 % (


### PR DESCRIPTION
Actualmente las pruebas de Travis fallan debido al siguiente error de flake8:
- [.psql_unittest.py:204:17: W503 line break before binary operator](https://travis-ci.org/LuisAlejandro/vauxoo-applicant/builds/111681393)

Este pull-request corrige el error.
